### PR TITLE
﻿feat: signup google on step 1, city loading text, robots.txt, .env.p…

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,23 @@
+# Vite picks this up automatically when running `npm run build` (and
+# also `vite build --mode production`). For local dev (`npm run dev`)
+# the values in `.env` win instead.
+#
+# All `VITE_*` values are baked into the production JS bundle and are
+# therefore PUBLIC — never put secrets here. The values below match the
+# pattern in `.env` but point at the live API instead of localhost.
+
+# Live FastAPI backend on AWS ECS Express Mode. Using the auto-generated
+# service URL for now; swap to `https://api.datryp.com` once the custom
+# domain is wired up (rebuild + redeploy required after the swap).
+VITE_PYTHON_API_URL=https://da-bbb88eb37a3748afb48647a3c30df78e.ecs.us-east-1.on.aws
+VITE_PYTHON_GRAPHQL_URL=https://da-bbb88eb37a3748afb48647a3c30df78e.ecs.us-east-1.on.aws/graphql
+
+# Google Sign-In OAuth Client ID — same Web client used in dev, no need
+# to create a separate prod client. Google verifies the Origin header
+# against the list in the OAuth client settings; add https://datryp.com
+# and https://www.datryp.com there if you haven't.
+VITE_GOOGLE_CLIENT_ID=167199571698-db0ieejp7nbdoj9vfqlc78k435l6p3hq.apps.googleusercontent.com
+
+# VAPID public key for Web Push notifications — public by design (the
+# matching private key lives on the backend, not here).
+VITE_VAPID_PUBLIC_KEY=BHCM5X3JsswnFtkgh5e0aVa_JqO6neLvMmNIUELIzuigXbu4bg0fOAJkVTC4y2Is2u4ZvjuwMgptnwyS_M9WBRM

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,31 @@
+# robots.txt for DaTryp.com
 # https://www.robotstxt.org/robotstxt.html
+#
+# Allow indexing of public content + marketing pages (home, about,
+# privacy/terms, city/country/place detail). Block user-specific and
+# auth-token pages — they have no SEO value and could leak PII or
+# expose reset tokens via search-engine caches.
+
 User-agent: *
-Disallow:
+
+# User-specific pages — gated behind login, never useful to index
+Disallow: /account
+Disallow: /trips
+Disallow: /trip-detail
+Disallow: /friends
+Disallow: /notifications
+Disallow: /history
+Disallow: /visited
+Disallow: /saved
+Disallow: /bucket-list
+Disallow: /dashboard
+
+# Trip-builder wizards — in-progress drafts, not standalone content
+Disallow: /single
+Disallow: /multiple
+
+# Auth flows — tokens in URLs (reset-password) or post-signup state
+# (membership/welcome) shouldn't end up in Google's cache
+Disallow: /forgot-password
+Disallow: /reset-password
+Disallow: /membership/welcome

--- a/src/components/Sections/CityDetail/index.tsx
+++ b/src/components/Sections/CityDetail/index.tsx
@@ -152,8 +152,10 @@ const CityDetail = () => {
                         Loading {name} details…
                     </p>
                     <p className="city-detail-loading-hint">
-                        First-time look-ups take a few seconds while we gather
-                        travel info.
+                        This city is new to us — gathering detailed travel
+                        info takes about a minute on first visit. Every
+                        future visit (yours and anyone else's) will be
+                        instant.
                     </p>
                 </div>
             </Layout>

--- a/src/components/Sections/Signup/StepName/index.tsx
+++ b/src/components/Sections/Signup/StepName/index.tsx
@@ -1,17 +1,28 @@
 /**
  * Step 1 — Name. Optional in the backend (signup accepts no name), so we
  * allow blank + Continue. Personal-feeling first question that warms the
- * user up to the flow.
+ * user up to the flow. Google sign-in is offered right here too so users
+ * who want the fast path don't have to type anything — clicking the
+ * Google button skips Steps 1-4 entirely and lands them in onboarding.
  */
+import GoogleSignInButton from 'components/GoogleSignInButton';
 import ButtonCustom from 'components/common/FormFields/ButtonCustom';
 
 export interface StepNameProps {
     value: string;
     onChange: (next: string) => void;
     onContinue: () => void;
+    onGoogleCredential: (credential: string) => void;
+    googlePending: boolean;
 }
 
-const StepName = ({ value, onChange, onContinue }: StepNameProps) => {
+const StepName = ({
+    value,
+    onChange,
+    onContinue,
+    onGoogleCredential,
+    googlePending,
+}: StepNameProps) => {
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') onContinue();
     };
@@ -40,6 +51,21 @@ const StepName = ({ value, onChange, onContinue }: StepNameProps) => {
                     label="Continue"
                     onClick={onContinue}
                 />
+            </div>
+            <div className="signup-divider">
+                <span>or</span>
+            </div>
+            <div className="signup-google-row">
+                <GoogleSignInButton
+                    text="signup_with"
+                    width={400}
+                    onCredential={onGoogleCredential}
+                />
+                {googlePending && (
+                    <span className="signup-google-pending">
+                        Signing you in…
+                    </span>
+                )}
             </div>
         </>
     );

--- a/src/components/Sections/Signup/index.tsx
+++ b/src/components/Sections/Signup/index.tsx
@@ -196,6 +196,8 @@ const Signup = () => {
                         value={draft.name}
                         onChange={(v) => setDraftField('name', v)}
                         onContinue={goNext}
+                        onGoogleCredential={handleGoogleCredential}
+                        googlePending={googleSignin.isPending}
                     />
                 );
             case 2:


### PR DESCRIPTION
…roduction

- StepName (signup step 1): show Continue-with-Google alongside the name field so users see the fast path immediately, not buried under step 2's email form.
- CityDetail: honest loading text — "~1 min on first visit, instant thereafter" so users don't think it's stuck during the OpenAI cold fetch.
- robots.txt: smarter rules — allow indexing of public/marketing/city detail pages, disallow account/trips/bucket-list/auth-token URLs.
- .env.production (new): VITE_PYTHON_API_URL points at the ECS service URL; baked into the prod bundle at build time. .env still uses localhost for `npm run dev`.