### PR TITLE
﻿feat: top-pick card -> country page -> auto-seed 4 highlights

### DIFF
--- a/src/api/hooks/useMonthlyBestPlace.ts
+++ b/src/api/hooks/useMonthlyBestPlace.ts
@@ -14,13 +14,24 @@ import { useUser } from 'context/UserContext';
  * calendar month). Frontend cache is 30 min just so repeated mounts
  * within a session don't re-fetch.
  */
-export const useMonthlyBestPlace = () => {
+export interface UseMonthlyBestPlaceOptions {
+    /** When provided, the query only fires if BOTH this flag and the
+     *  Pro/admin entitlement check pass. Callers that only want the
+     *  data on specific routes (e.g. the country page's seed CTA) can
+     *  set this to `false` on routes where the data isn't needed. */
+    enabled?: boolean;
+}
+
+export const useMonthlyBestPlace = (
+    options: UseMonthlyBestPlaceOptions = {}
+) => {
     const { user, isAdmin } = useUser();
     const entitled = Boolean(user && (user.isPaidMember || isAdmin));
+    const callerEnabled = options.enabled ?? true;
     return useQuery<MonthlyBestPlaceResult>({
         queryKey: ['me', 'monthly-best-place'],
         queryFn: fetchMonthlyBestPlace,
-        enabled: entitled,
+        enabled: entitled && callerEnabled,
         staleTime: 30 * 60 * 1000,
         retry: 1,
     });

--- a/src/components/MonthlyBestPlace/index.tsx
+++ b/src/components/MonthlyBestPlace/index.tsx
@@ -5,7 +5,10 @@
  * interests + traveler styles. Renders as a split-card with the place
  * photo on the left and the AI-written pitch + highlights on the right.
  *
- * Card click → /city detail page (same pattern as PYML and WorldEvent).
+ * Card click → /country detail page with `?seed=monthly-best-place` so
+ * the country page can offer a "plan trip with these picks" CTA that
+ * auto-seeds the 4 highlights as activities (saves the user from
+ * guessing what to add).
  *
  * Hidden entirely for signed-out + free-tier users (Pro-only, no teaser
  * — matches the silent-surprise pattern we use for Holiday).
@@ -28,15 +31,18 @@ const monthLabel = (monthKey: string): string => {
     return d.toLocaleString(undefined, { month: 'long', year: 'numeric' });
 };
 
-const goToCity = (
+const goToCountryWithSeed = (
     navigate: (to: string) => void,
     place: MonthlyBestPlaceInfo
 ) => {
+    // `?seed=monthly-best-place` tells the country page to surface the
+    // auto-add CTA that pre-seeds the 4 highlight activities into the
+    // new trip. Without the seed param, the country page renders the
+    // normal "Start planning" flow.
     navigate(
-        `/city?name=${encodeURIComponent(place.name)}` +
-            `&country=${encodeURIComponent(place.country)}` +
-            `&code=${encodeURIComponent(place.countryCode)}` +
-            `&mode=single`
+        `/country?code=${encodeURIComponent(place.countryCode)}` +
+            `&mode=single` +
+            `&seed=monthly-best-place`
     );
 };
 
@@ -93,13 +99,13 @@ const MonthlyBestPlaceActive = () => {
         <section className="monthly-best-place">
             <article
                 className="monthly-best-place-card"
-                onClick={() => goToCity(navigate, place)}
+                onClick={() => goToCountryWithSeed(navigate, place)}
                 role="link"
                 tabIndex={0}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        goToCity(navigate, place);
+                        goToCountryWithSeed(navigate, place);
                     }
                 }}
                 aria-label={`Open ${place.name}, ${place.country}`}

--- a/src/components/Sections/CountryDetail/index.tsx
+++ b/src/components/Sections/CountryDetail/index.tsx
@@ -36,9 +36,11 @@ import LodgingSection from "components/PlaceDetail/LodgingSection";
 import TipListSection from "components/PlaceDetail/TipListSection";
 import MainSection from "components/PlaceDetail/MainSection";
 import { useCountryDetails } from "api/hooks/useCountryDetails";
+import { useMonthlyBestPlace } from "api/hooks/useMonthlyBestPlace";
 import { useIsStuck } from "hooks/useIsStuck";
-import { basicInfo, resetTrip, useTripDispatch } from "context/TripContext";
-import { TRIP_BASIC } from "constants";
+import { addPlace, basicInfo, resetTrip, useTripDispatch } from "context/TripContext";
+import { now } from "utils";
+import { ACTIVITY_KIND, TRIP_BASIC } from "constants";
 import type { Destination } from "types";
 
 const CountryDetail = () => {
@@ -57,7 +59,28 @@ const CountryDetail = () => {
   const tripType =
     modeParam === "multiple" ? TRIP_BASIC.MULTIPLE : TRIP_BASIC.SINGLE;
 
+  // Seed flag — when arriving from the "Your top pick" homepage card we
+  // know which entry point this is and can offer a CTA that pre-fills
+  // the trip with the 4 highlights from that monthly pick (so the user
+  // doesn't have to guess what to add).
+  const seed = (searchParams.get("seed") ?? "").trim();
+  const isMonthlyBestPlaceSeed = seed === "monthly-best-place";
+
   const { data, isLoading, isError, error } = useCountryDetails(code);
+
+  // Only fetch the monthly pick when we're actually arriving via the
+  // seed flow — keeps the country page from hitting an extra endpoint
+  // for every normal visit. The hook itself gates on Pro+admin, so
+  // free users never see the seed CTA even if the URL has the param.
+  const monthlyBestPlace = useMonthlyBestPlace({
+    enabled: isMonthlyBestPlaceSeed,
+  });
+  // The seed CTA only makes sense when the monthly pick's country
+  // matches the country we're currently looking at (otherwise the 4
+  // highlights belong to a different country and would mis-seed).
+  const seedMatchesThisCountry =
+    isMonthlyBestPlaceSeed &&
+    monthlyBestPlace.data?.place.countryCode === code;
 
   const startTrip = (
     country: { id: string; name: string; code: string; local: string | null; image: string | null },
@@ -73,8 +96,45 @@ const CountryDetail = () => {
         },
       },
     ] as Destination[];
+    const today = now();
     dispatch(resetTrip());
-    dispatch(basicInfo({ type: tripType, destinations }));
+    dispatch(
+      basicInfo({
+        type: tripType,
+        destinations,
+        startDate: today,
+        endDate: today,
+        image: country.image ?? undefined,
+      }),
+    );
+
+    // Seed flow: when the user arrived via the "Your top pick"
+    // homepage card and the monthly pick's country matches this
+    // page, pre-fill the new trip with the 4 highlights as activity
+    // rows so the user lands in the wizard with content (not an
+    // empty itinerary they have to fill in).
+    if (seedMatchesThisCountry && monthlyBestPlace.data) {
+      const { place, highlights } = monthlyBestPlace.data;
+      const location = `${place.name}, ${country.name}`;
+      // Take up to 4 — guarantees the wizard's Day-1 doesn't get
+      // overwhelmed if the prompt ever returns more.
+      highlights.slice(0, 4).forEach((h) => {
+        dispatch(
+          addPlace({
+            value: {
+              kind: ACTIVITY_KIND.PLACE,
+              name: h.title,
+              note: h.description,
+              location,
+            },
+            index: 0,
+            date: today,
+            destinationIndx: 0,
+          }),
+        );
+      });
+    }
+
     navigate(tripType.route, { replace: true });
   };
 
@@ -187,9 +247,11 @@ const CountryDetail = () => {
               <FlightTakeoffRoundedIcon className="country-detail-plan-cta-icon" />
               <span className="country-detail-plan-cta-text">
                 <span className="country-detail-plan-cta-label">
-                  {tripType.id === TRIP_BASIC.MULTIPLE.id
-                    ? "Start multi-destination trip"
-                    : "Start planning"}
+                  {seedMatchesThisCountry
+                    ? "Plan trip with these picks"
+                    : tripType.id === TRIP_BASIC.MULTIPLE.id
+                      ? "Start multi-destination trip"
+                      : "Start planning"}
                 </span>
                 <span className="country-detail-plan-cta-target">
                   {country.name}


### PR DESCRIPTION
MonthlyBestPlace card click now navigates to `/country?code=XX&mode= single&seed=monthly-best-place` instead of the city page. The seed flag tells CountryDetail to surface a "Plan trip with these picks" CTA that pre-fills the 4 highlights from the monthly pick as Day-1 activities in the new trip — saves the user from guessing what to add.

useMonthlyBestPlace gains an optional `enabled` flag so the country page only fetches the pick when the URL actually has the seed param (no wasted network on normal country visits).

The seed CTA only fires when the monthly pick's country matches the current page — defensive guard against URL tampering or stale links where the pick has rotated to a different country since the original share.

Phase A (single-country). Phase B (multi-country, highlights with their own country codes) would need a backend change to enrich highlights with country fields; deferred until real multi-country picks show up.