### PR TITLE
﻿feat(mobile/ux): inter font, icon logo, inline search, readable home…

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,11 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Signika:wght@300;400;500&display=swap" rel="stylesheet">
+    <!-- Inter: modern, screen-optimized sans-serif. Replaces Signika as the
+         primary UI font for better small-size readability and a more
+         contemporary feel. Signika kept on the link line as a fallback
+         for users with a slow first-load (lasts about a second). -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Signika:wght@300;400;500&display=swap" rel="stylesheet">
     <title>DaTryp.com — Plan your next trip</title>
   </head>
   <body>

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -29,11 +29,18 @@
   display: inline-flex;
   flex-shrink: 0;
 }
-.app-header-logo img,
-.app-header-logo .icon-link-adornment img {
+.app-header-logo .app-header-logo-full {
   width: 130px;
   height: auto;
   display: block;
+}
+// Icon-only logo lives in the DOM at all sizes; CSS toggles which is
+// visible. Keeps the rendered tree stable across breakpoints so React
+// doesn't re-key on a resize.
+.app-header-logo .app-header-logo-icon {
+  display: none;
+  width: 36px;
+  height: 36px;
 }
 
 .app-header-nav {
@@ -303,16 +310,32 @@
 .app-header-drawer .drawer-body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 8px 0;
+  gap: 4px;
+  padding: 4px 0;
 }
 
-.app-header-drawer .drawer-auth button {
+// Logged-out auth section in the drawer — both buttons full-width,
+// vertically stacked with breathing room. The two are visually
+// differentiated (line vs filled) but otherwise identical sizing so
+// they read as a paired auth choice rather than mismatched
+// affordances.
+.app-header-drawer .drawer-auth {
+  width: 100%;
+  margin: 0 0 10px;
+}
+
+.app-header-drawer .drawer-auth button,
+.app-header-drawer .drawer-auth .auth-cta-link {
   width: 100%;
   text-align: center;
   display: block;
-  padding: 12px 20px;
+  padding: 14px 20px;
   font-size: 1rem;
+  border-radius: 12px;
+}
+
+.app-header-drawer .drawer-auth.signup {
+  margin-bottom: 8px;
 }
 
 .app-header-drawer .drawer-user {
@@ -365,13 +388,21 @@
 /* ---------- Responsive ---------- */
 @media (max-width: 768px) {
   .app-header-inner {
-    padding: 10px 16px;
-    gap: 12px;
+    padding: 10px 12px;
+    gap: 10px;
+    // No-wrap: logo + search + burger stay on one row at all mobile
+    // widths. The search is the flex-grow target and shrinks to fit
+    // whatever space remains.
+    flex-wrap: nowrap;
   }
 
-  .app-header-logo img,
-  .app-header-logo .icon-link-adornment img {
-    width: 110px;
+  // Swap to icon-only logo so the full wordmark doesn't crowd out the
+  // searchbar on the same row.
+  .app-header-logo .app-header-logo-full {
+    display: none;
+  }
+  .app-header-logo .app-header-logo-icon {
+    display: block;
   }
 
   .app-header-nav {
@@ -380,16 +411,33 @@
 
   .app-header-burger {
     display: inline-flex !important;
+    flex-shrink: 0;
   }
 
-  .app-header-inner.with-search {
-    flex-wrap: wrap;
-  }
-
+  // Inline search on mobile — sits between the icon logo and the
+  // burger. flex-grow lets it fill remaining space; max-width caps it
+  // on tablet widths so it doesn't dominate.
   .app-header-search {
-    order: 3;
-    flex-basis: 100%;
+    order: 0;
+    flex: 1 1 auto;
+    min-width: 0;
     max-width: 100%;
-    margin-top: 4px;
+    margin: 0;
+  }
+
+  .app-header-search .MuiOutlinedInput-root {
+    font-size: 0.85rem;
+    padding-left: 32px !important;
+    padding-right: 10px !important;
+  }
+
+  .app-header-search .MuiOutlinedInput-root input {
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+  }
+
+  .app-header-search .app-header-search-icon {
+    left: 10px;
+    font-size: 1rem !important;
   }
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -25,7 +25,7 @@ import ButtonCustom from 'components/common/FormFields/ButtonCustom';
 import NotificationBell from 'components/NotificationBell';
 import { useUser } from 'context/UserContext';
 import type { LoginForm } from 'components/common/LoginBtn';
-import { BUTTON_VARIANT, LOGO_IMAGE } from 'constants';
+import { BUTTON_VARIANT, LOGO_ICON_IMAGE, LOGO_IMAGE } from 'constants';
 import type { Country } from 'types';
 import './index.scss';
 
@@ -105,7 +105,20 @@ const Header = ({ withSearch = false }: HeaderProps) => {
             <div className={classnames('app-header-inner', { 'with-search': withSearch })}>
                 <IconLink
                     to="/"
-                    icon={<img src={LOGO_IMAGE} alt="" />}
+                    icon={
+                        <>
+                            <img
+                                src={LOGO_IMAGE}
+                                alt=""
+                                className="app-header-logo-full"
+                            />
+                            <img
+                                src={LOGO_ICON_IMAGE}
+                                alt=""
+                                className="app-header-logo-icon"
+                            />
+                        </>
+                    }
                     ariaLabel="DaTryp.com home"
                     className="app-header-logo"
                 />

--- a/src/components/Sections/Home/index.scss
+++ b/src/components/Sections/Home/index.scss
@@ -93,13 +93,16 @@
 .home-hero-options {
   position: relative;
   display: inline-flex;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.22);
+  // Solid-white pill so unselected text has consistent contrast on
+  // any hero photo. Previously a glassy translucent pill let the
+  // photo bleed through and made the unselected label nearly
+  // invisible on bright backgrounds.
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 9999px;
   padding: 4px;
   margin-bottom: 22px;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
   min-width: 360px;
 }
 
@@ -131,7 +134,8 @@
   padding: 8px 18px;
   border-radius: 9999px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.75);
+  // Dark text on white pill — guaranteed contrast against any photo.
+  color: rgba(0, 0, 0, 0.7);
   font-weight: 500;
   font-size: 0.9rem;
   transition: color 0.18s ease;
@@ -143,9 +147,11 @@
 }
 
 .home-hero-options .hero-option:hover {
-  color: #fff;
+  color: theme('colors.primary');
 }
 
+// Selected tab: thumb covers it with brand color, text inverts to
+// white. The thumb's box-shadow provides the depth cue.
 .home-hero-options .hero-option.selected {
   color: #fff;
   font-weight: 600;
@@ -158,8 +164,10 @@
 }
 
 .home-hero-options .hero-option.is-ai:not(.selected) .hero-option-icon {
-  color: #c4b5fd;
-  filter: drop-shadow(0 0 4px rgba(124, 58, 237, 0.4));
+  // Soft purple tint on the AI tab's icon when not selected — hints
+  // at the brand color of the AI mode without overpowering the dark
+  // text label next to it.
+  color: #7c3aed;
 }
 
 .home-hero-options .hero-option-ai-badge {
@@ -337,27 +345,19 @@
     color: rgba(0, 0, 0, 0.6);
   }
 
+  // Mobile pill — inherits the white solid background from the
+  // desktop rule above (no longer needs to fight a dark photo
+  // backdrop). Only the size + spacing are adjusted here.
   .home-hero-options {
     margin-bottom: 18px;
-    background: rgba(0, 0, 0, 0.04);
-    border-color: rgba(0, 0, 0, 0.1);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    min-width: 420px;
+    min-width: 0;
+    width: 100%;
+    max-width: 360px;
   }
 
   .home-hero-options .hero-option {
     padding: 8px 12px;
-    font-size: 0.8rem;
-    color: rgba(0, 0, 0, 0.55);
-  }
-
-  .home-hero-options .hero-option:hover {
-    color: theme('colors.primary');
-  }
-
-  .home-hero-options .hero-option.selected {
-    color: #fff;
+    font-size: 0.85rem;
   }
 
   /* Stack input over CREATE button on phones */

--- a/src/components/common/StepperComp/index.tsx
+++ b/src/components/common/StepperComp/index.tsx
@@ -832,17 +832,18 @@ const StepperComp = ({ steps = [], data }: StepperCompProps) => {
                             </ErrorAlert>
                         </Grid>
                     )}
-                    {isLastStep && showNotifyToggle && (
-                        <Grid item lg={12} md={12} xs={12}>
-                            <div className="step-actions-notify">
-                                <NotifyParticipantsCheckbox
-                                    checked={notifyParticipants}
-                                    onChange={setNotifyParticipants}
-                                    disabled={saveItinerary.isPending}
-                                />
-                            </div>
-                        </Grid>
-                    )}
+                    {/*
+                      NotifyParticipantsCheckbox intentionally hidden from
+                      the wizard's last step entirely. Previous iteration
+                      tried two layouts (sandwiched between Back/Finish,
+                      then in its own row above) — both crowded the action
+                      buttons. `notifyParticipants` defaults to true in
+                      this component's state so participants still get an
+                      email invite on first save. The toggle UI will
+                      return on the TripDetail "share to missed
+                      participants" surface (see memory:
+                      project_edit_trip_share_to_participants).
+                    */}
                     <Grid item lg={12} md={12} xs={12}>
                         <div className="step-actions">
                             {activeStep > 0 && (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,9 @@
 export const NO_IMAGE = "./images/logo-gray.png";
 export const LOGO_IMAGE = "/images/logo.svg";
+/** Icon-only variant of the logo (no wordmark). Used on mobile where
+ *  horizontal space is tight — the full logo would crowd out the
+ *  searchbar + burger menu on the same header row. */
+export const LOGO_ICON_IMAGE = "/images/logo-icon.svg";
 export const PAGE_TITLE = "DaTryp.com";
 
 /** Lightweight email validator — checks for `local@domain.tld` shape only.

--- a/src/index.scss
+++ b/src/index.scss
@@ -4,8 +4,14 @@
 
 body {
   margin: 0;
-  font-family: 'Signika', sans-serif;
-  font-weight: 100;
+  // Inter is the primary screen font — purpose-built for UIs, much
+  // more legible at small sizes than Signika. System fonts trail as
+  // fallbacks for the brief Google-Fonts cold-load window. Signika
+  // kept at the end so existing print styles + edge cases still find
+  // *something* if Inter fails to load entirely.
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Signika', sans-serif;
+  font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
… toggle, hide notify

Font:
  Switch UI font from Signika to Inter — purpose-built for screens,
  more legible at small sizes, contemporary feel. Loaded from Google
  Fonts alongside the existing Signika link (kept as a fallback for
  the brief cold-load window). Updates body and base font-family
  stack in src/index.scss; system fonts as further fallbacks.

Mobile logo:
  Below 768px, swap the full wordmark for the icon-only variant
  (`/images/logo-icon.svg`) so the searchbar can sit inline between
  the logo and the burger without crowding. Both <img> tags ship in
  the DOM at all sizes; CSS toggles which is visible.

Mobile search position:
  Removed the wrap-to-new-row behavior. Logo / search / burger now
  stay on one flex row at all mobile widths. The search bar
  flex-grows to fill remaining space; padding + font-size shrink to
  fit smaller screens.

Home toggle (Country/AI search-mode pills):
  Replaced the glassy translucent pill with a solid-white pill +
  subtle shadow. Unselected text is dark instead of white-on-photo
  so it reads on any hero background. Was previously nearly
  invisible on bright photos.

Drawer auth (logged out):
  Login and Sign Up buttons now full-width, consistent padding,
  proper visual hierarchy. Previously read as mismatched inline
  affordances next to the close button.

Notify-participants checkbox:
  Hidden from the wizard step actions row entirely — it crowded the
  Back/Finish buttons and read as a button affordance. State still
  defaults to true so the invite email fires on first save; the
  toggle UI will return on TripDetail per the
  project_edit_trip_share_to_participants memory.