### PR TITLE
﻿feat(airports): autocomplete picker on flight form

### DIFF
--- a/src/api/airportsApi.ts
+++ b/src/api/airportsApi.ts
@@ -1,0 +1,58 @@
+/**
+ * `/airports/search` — IATA-code/airport-name/city autocomplete backed
+ * by the static `airports` catalog on the backend (~200 entries today,
+ * grows with seed updates). Results are stable across deploys so the
+ * client can cache aggressively.
+ */
+const API_BASE =
+    import.meta.env.VITE_PYTHON_API_URL ?? 'http://localhost:8000';
+
+export interface AirportOption {
+    iataCode: string;
+    name: string;
+    city: string;
+    countryCode: string;
+    country: string;
+}
+
+export interface AirportsSearchResult {
+    items: AirportOption[];
+}
+
+interface AirportRaw {
+    iata_code: string;
+    name: string;
+    city: string;
+    country_code: string;
+    country: string;
+}
+
+interface AirportsResponseRaw {
+    items: AirportRaw[];
+}
+
+const toOption = (a: AirportRaw): AirportOption => ({
+    iataCode: a.iata_code,
+    name: a.name,
+    city: a.city,
+    countryCode: a.country_code,
+    country: a.country,
+});
+
+export const searchAirports = async (
+    q: string,
+    limit = 20,
+): Promise<AirportsSearchResult> => {
+    const trimmed = q.trim();
+    if (!trimmed) return { items: [] };
+    const resp = await fetch(
+        `${API_BASE}/airports/search` +
+            `?q=${encodeURIComponent(trimmed)}` +
+            `&limit=${limit}`,
+    );
+    if (!resp.ok) {
+        throw new Error(`/airports/search ${resp.status}`);
+    }
+    const body = (await resp.json()) as AirportsResponseRaw;
+    return { items: body.items.map(toOption) };
+};

--- a/src/api/hooks/useAirports.ts
+++ b/src/api/hooks/useAirports.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+    searchAirports,
+    type AirportsSearchResult,
+} from 'api/airportsApi';
+
+/**
+ * Live airport search. Pass the input value; the hook hits
+ * `/airports/search?q=...` and returns ranked matches. Disabled when
+ * the query is empty so we don't burn requests on initial mount.
+ *
+ * Cache is 24 hours — the underlying airports catalog only changes
+ * when the seed script runs, which is rare.
+ */
+export const useAirports = (query: string) => {
+    const trimmed = query.trim();
+    return useQuery<AirportsSearchResult>({
+        queryKey: ['airports', 'search', trimmed.toLowerCase()],
+        queryFn: () => searchAirports(trimmed),
+        enabled: trimmed.length >= 1,
+        staleTime: 24 * 60 * 60 * 1000,
+        retry: 1,
+    });
+};

--- a/src/components/common/AddPlaceBtn/index.tsx
+++ b/src/components/common/AddPlaceBtn/index.tsx
@@ -7,6 +7,7 @@ import StickyNote2RoundedIcon from '@mui/icons-material/StickyNote2Rounded';
 import FlightRoundedIcon from '@mui/icons-material/FlightRounded';
 import ModalButton, { type ModalButtonHandle } from 'components/ModalButton';
 import InputField from 'components/common/FormFields/InputField';
+import AirportAutocomplete from 'components/common/FormFields/AirportAutocomplete';
 import ButtonCustom from 'components/common/FormFields/ButtonCustom';
 import ErrorAlert from 'components/common/ErrorAlert';
 import PlaceAutocomplete, {
@@ -551,31 +552,31 @@ const AddPlaceBtn = ({
                                                         />
                                                     </Grid>
                                                     <Grid item lg={6} xs={12} className="py-5">
-                                                        <InputField
+                                                        <AirportAutocomplete
                                                             value={segment.departAirport ?? ''}
-                                                            name={`departAirport-${segIdx}`}
-                                                            label="Depart airport (IATA)"
-                                                            onChange={(e) =>
+                                                            onChange={(code) =>
                                                                 handleSegmentField(
                                                                     segIdx,
                                                                     'departAirport',
-                                                                    e.target.value.toUpperCase()
+                                                                    code
                                                                 )
                                                             }
+                                                            label="Depart airport"
+                                                            placeholder="IATA code, city, or airport"
                                                         />
                                                     </Grid>
                                                     <Grid item lg={6} xs={12} className="py-5 lg:pl-2">
-                                                        <InputField
+                                                        <AirportAutocomplete
                                                             value={segment.arrivalAirport ?? ''}
-                                                            name={`arrivalAirport-${segIdx}`}
-                                                            label="Arrival airport (IATA)"
-                                                            onChange={(e) =>
+                                                            onChange={(code) =>
                                                                 handleSegmentField(
                                                                     segIdx,
                                                                     'arrivalAirport',
-                                                                    e.target.value.toUpperCase()
+                                                                    code
                                                                 )
                                                             }
+                                                            label="Arrival airport"
+                                                            placeholder="IATA code, city, or airport"
                                                         />
                                                     </Grid>
                                                     <Grid item lg={6} xs={12} className="py-5">

--- a/src/components/common/FormFields/AirportAutocomplete/index.scss
+++ b/src/components/common/FormFields/AirportAutocomplete/index.scss
@@ -1,0 +1,41 @@
+.airport-autocomplete {
+  width: 100%;
+}
+
+// Dropdown row — 3-column readable layout: IATA code badge / city /
+// country. The list itself is rendered into a portal by MUI so this
+// styling targets the option `<li>` regardless of where it ends up
+// in the tree.
+.airport-autocomplete-option {
+  display: grid !important;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px !important;
+  font-size: 0.9rem;
+}
+
+.airport-autocomplete-option-code {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: theme('colors.primary');
+  background: rgba(60, 181, 75, 0.1);
+  padding: 2px 6px;
+  border-radius: 6px;
+  text-align: center;
+}
+
+.airport-autocomplete-option-city {
+  font-weight: 500;
+  color: theme('colors.primary');
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.airport-autocomplete-option-country {
+  font-size: 0.78rem;
+  color: rgba(0, 0, 0, 0.55);
+  white-space: nowrap;
+}

--- a/src/components/common/FormFields/AirportAutocomplete/index.tsx
+++ b/src/components/common/FormFields/AirportAutocomplete/index.tsx
@@ -1,0 +1,148 @@
+/**
+ * Airport picker with autocomplete. Backed by `/airports/search` on the
+ * Python backend (static IATA catalog seeded from `app/data/airports.py`).
+ *
+ * Usage — same shape as a controlled text input:
+ *
+ *     <AirportAutocomplete
+ *         value={segment.departAirport ?? ''}
+ *         onChange={(code) => setSegment({ ...segment, departAirport: code })}
+ *         label="From"
+ *         placeholder="e.g. JFK, Tokyo, Heathrow"
+ *     />
+ *
+ * `value` and `onChange` carry the IATA code (e.g. "JFK"). The component
+ * shows a richer "JFK — New York, United States" row in the dropdown
+ * but only persists the code, matching the existing FlightInfo.depart/
+ * arrivalAirport shape.
+ *
+ * `freeSolo` means the user can type any string (e.g. a code for an
+ * airport not in our static catalog) and it gets saved as-is. The
+ * dropdown is just a convenience layer — anything they type without
+ * picking from the list ends up in the form state too.
+ */
+import { Autocomplete, CircularProgress, TextField } from '@mui/material';
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+import { useAirports } from 'api/hooks/useAirports';
+import type { AirportOption } from 'api/airportsApi';
+import './index.scss';
+
+export interface AirportAutocompleteProps {
+    /** IATA code currently saved. Empty string when no airport picked yet. */
+    value: string;
+    /** Fires with the new IATA code (or free-typed text uppercased). */
+    onChange: (iataCode: string) => void;
+    label?: string;
+    placeholder?: string;
+    /** Disable input while a parent save is in flight. */
+    disabled?: boolean;
+    /** Forwarded to the underlying TextField — useful for form layouts. */
+    fullWidth?: boolean;
+}
+
+const AirportAutocomplete = ({
+    value,
+    onChange,
+    label,
+    placeholder = 'IATA code, city, or airport',
+    disabled,
+    fullWidth = true,
+}: AirportAutocompleteProps) => {
+    // Track the input string separately from the persisted IATA code.
+    // This lets the user clear the field, retype, and see fresh search
+    // results without us re-deriving the input from the value prop.
+    const [inputValue, setInputValue] = useState<string>(value);
+    const { data, isFetching } = useAirports(inputValue);
+    const options = data?.items ?? [];
+
+    const handleChange = (
+        _event: SyntheticEvent,
+        newValue: AirportOption | string | null,
+    ) => {
+        if (newValue == null) {
+            onChange('');
+            return;
+        }
+        if (typeof newValue === 'string') {
+            // User pressed Enter on a free-typed string — uppercase + trim
+            // and store. Doesn't have to be in our catalog.
+            onChange(newValue.trim().toUpperCase());
+            return;
+        }
+        onChange(newValue.iataCode);
+    };
+
+    return (
+        <Autocomplete<AirportOption, false, false, true>
+            className="airport-autocomplete"
+            freeSolo
+            // Server-side ranking — disable client filter so we don't
+            // double-filter the already-ranked list.
+            filterOptions={(x) => x}
+            options={options}
+            // `value` is the source of truth IATA code (string); we
+            // surface it via inputValue rather than try to map back to
+            // an AirportOption object.
+            value={null}
+            inputValue={inputValue || value || ''}
+            onInputChange={(_event, newInput, reason) => {
+                if (reason === 'reset' && !newInput) return;
+                setInputValue(newInput);
+            }}
+            onChange={handleChange}
+            getOptionLabel={(option) =>
+                typeof option === 'string' ? option : option.iataCode
+            }
+            isOptionEqualToValue={(opt, val) =>
+                typeof val === 'string'
+                    ? opt.iataCode === val
+                    : opt.iataCode === val.iataCode
+            }
+            renderOption={(props, option) => (
+                <li
+                    {...props}
+                    key={option.iataCode}
+                    className="airport-autocomplete-option"
+                >
+                    <span className="airport-autocomplete-option-code">
+                        {option.iataCode}
+                    </span>
+                    <span className="airport-autocomplete-option-city">
+                        {option.city}
+                    </span>
+                    <span className="airport-autocomplete-option-country">
+                        {option.country}
+                    </span>
+                </li>
+            )}
+            disabled={disabled}
+            fullWidth={fullWidth}
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    label={label}
+                    placeholder={placeholder}
+                    variant="outlined"
+                    size="small"
+                    InputProps={{
+                        ...params.InputProps,
+                        endAdornment: (
+                            <>
+                                {isFetching ? (
+                                    <CircularProgress
+                                        color="inherit"
+                                        size={14}
+                                    />
+                                ) : null}
+                                {params.InputProps.endAdornment}
+                            </>
+                        ),
+                    }}
+                />
+            )}
+        />
+    );
+};
+
+export default AirportAutocomplete;


### PR DESCRIPTION
Frontend half of the airport-picker autocomplete. Replaces the two bare IATA-code text inputs on the AddPlaceBtn flight form with a proper dropdown autocomplete backed by GET /airports/search.

What landed:
  - api/airportsApi.ts — fetch + camelCase normalize
  - api/hooks/useAirports.ts — React Query hook, 24h cache (catalog is static)
  - components/common/FormFields/AirportAutocomplete/ — MUI Autocomplete in freeSolo mode so users can also type codes not in our catalog; dropdown row shows IATA badge + city + country
  - AddPlaceBtn flight form swaps two InputFields for AirportAutocomplete

The component persists just the IATA code (matching the existing FlightInfo.departAirport / arrivalAirport shape) — no schema change needed.

Depends on backend feature/airport-autocomplete being deployed first so the /airports/search endpoint exists.