### PR TITLE
﻿feat: TripExpenseSummary on trip-detail (per-payer totals + print)

### DIFF
--- a/src/components/Sections/TripDetail/index.tsx
+++ b/src/components/Sections/TripDetail/index.tsx
@@ -22,6 +22,7 @@ import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import Layout from "components/common/Layout/SubLayout";
 import BasicTripInfo from "components/BasicTripInfo";
 import BudgetSummary from "components/BudgetSummary";
+import TripExpenseSummary from "components/TripExpenseSummary";
 import DestinationDetail from "components/DestinationDetail";
 import ButtonCustom from "components/common/FormFields/ButtonCustom";
 import ModalButton, {
@@ -526,6 +527,14 @@ export const TripDetail = () => {
             onChangeBudget={handleChangeBudget}
             tripStatusName={persistedStatusName}
           />
+        </Grid>
+        <Grid item lg={12} md={12} xs={12}>
+          {/* Per-payer expense breakdown — shown at the bottom of the
+              trip page so it's the last thing visible before scrolling
+              away. Also picked up by the print stylesheet so paper
+              copies carry the same totals + per-payer split as the
+              Excel export. Hidden when no budget items exist. */}
+          <TripExpenseSummary data={tripData} />
         </Grid>
       </Grid>
     </Layout>

--- a/src/components/TripExpenseSummary/index.scss
+++ b/src/components/TripExpenseSummary/index.scss
@@ -1,0 +1,93 @@
+.trip-expense-summary {
+  margin: 24px 0 8px;
+  padding: 18px 20px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.trip-expense-summary-title {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: theme('colors.primary');
+  letter-spacing: -0.005em;
+}
+
+.trip-expense-summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.trip-expense-summary-table td {
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.trip-expense-summary-row td,
+.trip-expense-summary-balance-row td {
+  font-size: 0.88rem;
+}
+
+.trip-expense-summary-label {
+  color: rgba(0, 0, 0, 0.78);
+  font-weight: 500;
+}
+
+.trip-expense-summary-amount {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: theme('colors.primary');
+  font-weight: 600;
+}
+
+.trip-expense-summary-percent {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 0.82rem;
+  width: 64px;
+  padding-left: 12px;
+}
+
+// Top "Total" row reads as a header — bigger, darker, with a thicker
+// separator below.
+.trip-expense-summary-total-row td {
+  font-size: 1rem;
+  font-weight: 700;
+  padding-top: 4px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid rgba(0, 0, 0, 0.12);
+}
+
+.trip-expense-summary-total-row .trip-expense-summary-label,
+.trip-expense-summary-total-row .trip-expense-summary-amount {
+  color: theme('colors.primary');
+}
+
+.trip-expense-summary-total-row .trip-expense-summary-percent {
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+// Unassigned/balance row — orange-ish tint to draw the eye, since it
+// indicates an action item ("someone needs to claim these expenses").
+.trip-expense-summary-balance-row td {
+  color: theme('colors.primaryOrange');
+  font-weight: 600;
+  border-bottom: none;
+}
+
+.trip-expense-summary-balance-row .trip-expense-summary-amount {
+  color: theme('colors.primaryOrange');
+}
+
+.trip-expense-summary-hint {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.55);
+  line-height: 1.4;
+}

--- a/src/components/TripExpenseSummary/index.tsx
+++ b/src/components/TripExpenseSummary/index.tsx
@@ -1,0 +1,138 @@
+/**
+ * Per-payer expense breakdown for a trip. Matches the bottom block of
+ * the Excel export — Total + per-payer totals with percentages +
+ * Balance row. Useful both on screen (organizers want this glance
+ * any time, not just when exporting) and in print (prints with the
+ * rest of the trip detail page so paper copies are usable).
+ *
+ * Hidden entirely when no budget items exist on any activity — a
+ * solo trip with zero expense splits doesn't need this section.
+ */
+import { useMemo } from 'react';
+import { convertMoney } from 'utils';
+import type { Destination, TripState } from 'types';
+import './index.scss';
+
+interface TripExpenseSummaryProps {
+    data: TripState;
+}
+
+interface PayerLine {
+    name: string;
+    total: number;
+}
+
+interface ExpenseTotals {
+    grandTotal: number;
+    perPayer: PayerLine[];
+    balance: number;
+}
+
+const toNumber = (v?: string | number): number => {
+    if (v == null) return 0;
+    const n = typeof v === 'number' ? v : parseFloat(v);
+    return Number.isFinite(n) ? n : 0;
+};
+
+const computeTotals = (destinations: Destination[] = []): ExpenseTotals => {
+    const byPayer = new Map<string, number>();
+    let grandTotal = 0;
+    let activityCostTotal = 0;
+
+    for (const dest of destinations) {
+        for (const day of dest.itinerary ?? []) {
+            for (const activity of day.activities ?? []) {
+                activityCostTotal += toNumber(activity.cost);
+                for (const b of activity.budget ?? []) {
+                    const name =
+                        b.user?.label ?? b.user?.name ?? '(unknown)';
+                    const amt = toNumber(b.budget);
+                    byPayer.set(name, (byPayer.get(name) ?? 0) + amt);
+                    grandTotal += amt;
+                }
+            }
+        }
+    }
+
+    const perPayer = Array.from(byPayer.entries())
+        .map(([name, total]) => ({ name, total }))
+        .sort((a, b) => b.total - a.total);
+
+    // Balance = activity-level cost that isn't accounted for in any
+    // budget split. Positive number means some expenses haven't been
+    // assigned to a payer yet (worth surfacing rather than hiding).
+    // Negative would indicate over-allocation — also worth seeing.
+    const balance = activityCostTotal - grandTotal;
+
+    return { grandTotal, perPayer, balance };
+};
+
+const TripExpenseSummary = ({ data }: TripExpenseSummaryProps) => {
+    const { grandTotal, perPayer, balance } = useMemo(
+        () => computeTotals(data.destinations),
+        [data.destinations],
+    );
+
+    // No budget splits → no value in showing the section. Don't
+    // render anything so the page stays tight.
+    if (perPayer.length === 0 && Math.abs(balance) < 0.01) {
+        return null;
+    }
+
+    return (
+        <section className="trip-expense-summary">
+            <h3 className="trip-expense-summary-title">Expense summary</h3>
+            <table className="trip-expense-summary-table">
+                <tbody>
+                    <tr className="trip-expense-summary-total-row">
+                        <td className="trip-expense-summary-label">Total</td>
+                        <td className="trip-expense-summary-amount">
+                            {convertMoney(grandTotal)}
+                        </td>
+                        <td className="trip-expense-summary-percent">100%</td>
+                    </tr>
+                    {perPayer.map((p) => {
+                        const percent =
+                            grandTotal > 0 ? (p.total / grandTotal) * 100 : 0;
+                        return (
+                            <tr
+                                key={p.name}
+                                className="trip-expense-summary-row"
+                            >
+                                <td className="trip-expense-summary-label">
+                                    {p.name}
+                                </td>
+                                <td className="trip-expense-summary-amount">
+                                    {convertMoney(p.total)}
+                                </td>
+                                <td className="trip-expense-summary-percent">
+                                    {percent.toFixed(1)}%
+                                </td>
+                            </tr>
+                        );
+                    })}
+                    {Math.abs(balance) >= 0.01 && (
+                        <tr className="trip-expense-summary-balance-row">
+                            <td className="trip-expense-summary-label">
+                                Unassigned
+                            </td>
+                            <td className="trip-expense-summary-amount">
+                                {convertMoney(balance)}
+                            </td>
+                            <td className="trip-expense-summary-percent" />
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+            {Math.abs(balance) >= 0.01 && (
+                <p className="trip-expense-summary-hint">
+                    {balance > 0
+                        ? `${convertMoney(balance)} of activity costs aren't assigned to a payer yet.`
+                        : `Payer splits exceed the activity totals by ${convertMoney(Math.abs(balance))}.`}
+                </p>
+            )}
+        </section>
+    );
+};
+
+export default TripExpenseSummary;

--- a/src/index.scss
+++ b/src/index.scss
@@ -300,4 +300,72 @@ code {
     opacity: 1 !important;
     filter: none !important;
   }
+
+  // ── Expense summary block ───────────────────────────────────────
+  // Per-payer breakdown that lives at the bottom of /trip-detail.
+  // The screen card chrome (rounded corners, shadow, white fill)
+  // gets stripped by the universal reset; we add back the spacing,
+  // a bottom-of-page anchor (page-break-before: avoid keeps it tied
+  // to the itinerary when possible), and the table aesthetics that
+  // make per-payer totals readable on paper.
+  .trip-expense-summary {
+    margin: 8pt 0 0 !important;
+    padding: 6pt 0 0 !important;
+    border-top: 0.5pt solid #000 !important;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .trip-expense-summary-title {
+    margin: 0 0 4pt !important;
+    font-size: 11pt !important;
+    font-weight: 700;
+  }
+
+  .trip-expense-summary-table {
+    width: 100% !important;
+    border-collapse: collapse !important;
+    font-size: 9.5pt !important;
+  }
+
+  .trip-expense-summary-table td {
+    padding: 2pt 4pt !important;
+    border: none !important;
+    border-bottom: 0.25pt solid rgba(0, 0, 0, 0.3) !important;
+  }
+
+  .trip-expense-summary-label {
+    font-weight: 500;
+  }
+
+  .trip-expense-summary-amount {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .trip-expense-summary-percent {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    width: 48pt !important;
+    white-space: nowrap;
+  }
+
+  .trip-expense-summary-total-row td {
+    font-weight: 700 !important;
+    border-bottom: 0.75pt solid #000 !important;
+    padding: 4pt 4pt !important;
+  }
+
+  .trip-expense-summary-balance-row td {
+    border-bottom: none !important;
+    font-weight: 700 !important;
+  }
+
+  .trip-expense-summary-hint {
+    margin: 4pt 0 0 !important;
+    font-size: 8.5pt !important;
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
New component shown at the bottom of /trip-detail: Total + per-payer totals with percentages + Balance row. Mirrors the bottom block of the Excel export so screen, paper, and spreadsheet all carry the same expense breakdown.

What's new:
  - components/TripExpenseSummary/ — computes per-payer totals from activity.budget entries; "Balance" surfaces unassigned costs (activity.cost without a matching budget split) rather than silently dropping them
  - Hidden when no budget items exist (don't add empty noise for solo trips)
  - Print stylesheet adds rules so the section formats cleanly on paper: tabular numbers, page-break-inside avoid, top border that separates it from the itinerary

Replaces the manual recall + spreadsheet calculation organizers were doing to figure out who owes whom. Same data as the Excel export's bottom block, just always visible on screen.